### PR TITLE
Support install pacaur from custom repo

### DIFF
--- a/arch-travis.sh
+++ b/arch-travis.sh
@@ -192,18 +192,23 @@ run_build_script() {
 
 # setup pacaur
 setup_pacaur() {
-  local cowerarchive="cower.tar.gz"
-  local aururl="https://aur.archlinux.org/cgit/aur.git/snapshot/"
-  # install cower
-  as_normal "curl -O $aururl/$cowerarchive"
-  as_normal "tar xf $cowerarchive"
-  chroot_as_normal "cd cower && makepkg -is --skippgpcheck --noconfirm"
-  as_root "rm -r cower"
-  as_normal "rm $cowerarchive"
-  # install pacaur
-  chroot_as_normal "cower -dd pacaur"
-  chroot_as_normal "cd pacaur && makepkg -is --noconfirm"
-  chroot_as_normal "rm -rf pacaur"
+  # Check if pacaur is available in the added repos
+  if chroot_as_normal "pacman -Si pacaur" &> /dev/null; then
+    chroot_as_root "pacman -S --noconfirm pacaur"
+  else
+    local cowerarchive="cower.tar.gz"
+    local aururl="https://aur.archlinux.org/cgit/aur.git/snapshot/"
+    # install cower
+    as_normal "curl -O $aururl/$cowerarchive"
+    as_normal "tar xf $cowerarchive"
+    chroot_as_normal "cd cower && makepkg -is --skippgpcheck --noconfirm"
+    as_root "rm -r cower"
+    as_normal "rm $cowerarchive"
+    # install pacaur
+    chroot_as_normal "cower -dd pacaur"
+    chroot_as_normal "cd pacaur && makepkg -is --noconfirm"
+    chroot_as_normal "rm -rf pacaur"
+  fi
 }
 
 # install package through pacaur


### PR DESCRIPTION
`pacaur` and it's dependencies are available in some custom repos (e.g. archlinuxcn) and this triggers a [build failure](https://travis-ci.org/yuyichao/LibALPM.jl/builds/122123876#L429). Maybe there's a way to suppress the warning/error from `cower` (haven't used it so not sure) but might as well use it if it is available.

P.S. Thanks so much for this travis script!!
