### PR TITLE
Pin systemd to previous version.

### DIFF
--- a/arch-travis.sh
+++ b/arch-travis.sh
@@ -128,6 +128,9 @@ setup_chroot() {
   # enable multilib
   as_root "sed -i 's|#\[multilib\]|\[multilib\]\nInclude = /etc/pacman.d/mirrorlist|' $ARCH_TRAVIS_CHROOT/etc/pacman.conf"
 
+  # pin systemd
+  as_root "sed -i 's|#IgnorePkg   =|IgnorePkg   = systemd libsystemd|' $ARCH_TRAVIS_CHROOT/etc/pacman.conf"
+
   # add mirrors
   for mirror in "${mirrors[@]}"; do
     mirror_entry="$(printf "$mirror_entry_fmt" $mirror)"


### PR DESCRIPTION
Pin `systemd` package to latest iso version to avoid dl-open error:

```
Inconsistency detected by ld.so: dl-open.c: 689: _dl_open: Assertion `_dl_debug_initialize (0, args.nsid)->r_state == RT_CONSISTENT' failed!
```

Temp fix for #33 