### PR TITLE
Pin previous ISO from December 2017

### DIFF
--- a/arch-travis.sh
+++ b/arch-travis.sh
@@ -55,7 +55,7 @@ repo_line=70
 # month, falling back to the last month if needed.
 get_base_archive() {
   local months=(
-    $(date +%Y.%m)
+    # $(date +%Y.%m)
     $(date +%Y.%m -d "-1 month")
   )
 


### PR DESCRIPTION
Use ISO from last month with working systemd version.

This is a temporary fix for #33 