### PR TITLE
Fix ISO to known good version

### DIFF
--- a/arch-travis.sh
+++ b/arch-travis.sh
@@ -56,7 +56,8 @@ repo_line=70
 get_base_archive() {
   local months=(
     # $(date +%Y.%m)
-    $(date +%Y.%m -d "-1 month")
+    # $(date +%Y.%m -d "-1 month")
+    '2017.12' # hardcoded to known good month
   )
 
   for mirror in "${mirrors[@]}"; do


### PR DESCRIPTION
New month is coming up meaning we will soon get a new iso which will start to break stuff.

This hardcodes a known good version of the ISO without a broken systemd version and is a workaround until we find a real fix for #33