### PR TITLE
Added Way Cooler, removed Sway from project list

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ compiler: clang
 
 ## Projects using arch-travis
 
+* [Way Cooler](https://github.com/way-cooler/way-cooler)
 * [networkd-dispatcher](https://github.com/craftyguy/networkd-dispatcher)
 
 ## LICENSE

--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ compiler: clang
 
 ## Projects using arch-travis
 
-* [sway](https://github.com/SirCmpwn/sway)
 * [networkd-dispatcher](https://github.com/craftyguy/networkd-dispatcher)
 
 ## LICENSE


### PR DESCRIPTION
Sway no longer uses arch-travis.

Way Cooler, however, uses arch travis and has for some time.