### PR TITLE
exit execution if a script returns non-successful

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -79,7 +79,7 @@ build_scripts() {
   if [ ${#CONFIG_BUILD_SCRIPTS[@]} -gt 0 ]; then
     for script in "${CONFIG_BUILD_SCRIPTS[@]}"; do
       echo "\$ $script"
-      eval "$script"
+      eval "$script" || exit $?
     done
   else
     echo "No build scripts defined"


### PR DESCRIPTION
Without exiting on failure the only thing that matters is the
return code of the last script call, which means you can have
all test calls failing as long as the last like does something
that returns success.