### PR TITLE
[Merge ready] Aggregated => travis ccache, base64 encoding, null separated script, fix LC_ALL, force shellcheck resolve.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ arch:
   - procps-ng
   - reflector
   - screenfetch-git
+  mount:
+  - ~/.pkg-cache:/var/cache/pacman/pkg
   before_install:
   - sudo sed -i '/#MAKEFLAGS=/c MAKEFLAGS="-j2"' /etc/makepkg.conf
   script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ arch:
   - screenfetch-git
   mount:
   - ~/.pkg-cache:/var/cache/pacman/pkg
+  - ~/.ccache:~/.ccache
+# test space character in path
+  - $HOME/y ay:$HOME/y ay
   before_install:
   - sudo sed -i '/#MAKEFLAGS=/c MAKEFLAGS="-j2"' /etc/makepkg.conf
   script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ arch:
   - procps-ng
   - reflector
   - screenfetch-git
+  before_install:
+  - sudo sed -i '/#MAKEFLAGS=/c MAKEFLAGS="-j2"' /etc/makepkg.conf
   script:
   - sudo screenfetch
   - reflector --verbose -l 20 --sort rate -p https

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ arch:
   - reflector --verbose -l 20 --sort rate -p https
   - echo $CC
   - touch test_file
+  - |
+    for ((i=0;i<10;i++)) ; do
+      echo test$i
+    done
 
 script:
 # build new image

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ arch:
   - go-git
   # packages from papyros repo
   - papyros-shell
+  before_install:
+  - "sudo ln -s /dev/null /etc/pacman.d/hooks/package-cleanup.hook"
   script:
   - "./build_script.sh"
 
@@ -33,6 +35,11 @@ script:
 
 `arch.packages` defines a list of packages (from official repos or AUR) to be
 installed before running the build.
+
+`arch.before_install` defines a list of scripts to run after system boots.
+It's purpose is to alter build environment before system update and packages
+installation. Anything defined in the `arch.before_install` list will run from
+the base of the repository as a normal user called `travis`, `sudo` is available.
 
 `arch.script` defines a list of scripts to run as part of the build. Anything
 defined in the `arch.script` list will run from the base of the repository as a

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ arch:
   - go-git
   # packages from papyros repo
   - papyros-shell
+  mount:
+  - ~/.pkg-cache:/var/cache/pacman/pkg
   before_install:
   - "sudo ln -s /dev/null /etc/pacman.d/hooks/package-cleanup.hook"
   script:
@@ -35,6 +37,9 @@ script:
 
 `arch.packages` defines a list of packages (from official repos or AUR) to be
 installed before running the build.
+
+`arch.mount` defines a list of shared folders (docker volumes) from travis host to build container.
+Format: `host_src:container_dst` (relative path and environment variables are supported)
 
 `arch.before_install` defines a list of scripts to run after system boots.
 It's purpose is to alter build environment before system update and packages

--- a/arch-travis.sh
+++ b/arch-travis.sh
@@ -32,6 +32,7 @@ encode_config() {
 }
 
 # read travis config
+CONFIG_BEFORE_INSTALL=$(encode_config arch before_install)
 CONFIG_BUILD_SCRIPTS=$(encode_config arch script)
 CONFIG_PACKAGES=$(encode_config arch packages)
 CONFIG_REPOS=$(encode_config arch repos)
@@ -41,6 +42,7 @@ mapfile -t envs < <(ruby -e 'ENV.each {|key,_| if not ["PATH","USER","HOME","GOR
 docker run --rm -v "$(pwd):/build" \
     -e "CC=$CC" \
     -e "CXX=$CXX" \
+    -e CONFIG_BEFORE_INSTALL="$CONFIG_BEFORE_INSTALL" \
     -e CONFIG_BUILD_SCRIPTS="$CONFIG_BUILD_SCRIPTS" \
     -e CONFIG_PACKAGES="$CONFIG_PACKAGES" \
     -e CONFIG_REPOS="$CONFIG_REPOS" \

--- a/arch-travis.sh
+++ b/arch-travis.sh
@@ -55,5 +55,5 @@ docker run --rm \
     -e CONFIG_BUILD_SCRIPTS="$CONFIG_BUILD_SCRIPTS" \
     -e CONFIG_PACKAGES="$CONFIG_PACKAGES" \
     -e CONFIG_REPOS="$CONFIG_REPOS" \
-    "${envs[@]}" \
+    ${envs[@]} \
     mikkeloscar/arch-travis:latest

--- a/arch-travis.sh
+++ b/arch-travis.sh
@@ -21,14 +21,7 @@ travis_yml() {
 
 # encode config so it can be passed to docker in an environment var.
 encode_config() {
-    local old_ifs=$IFS
-    IFS=$'\n'
-    local sep="::::"
-    arr=("$(travis_yml "$@")")
-    enc="$(printf "${sep}%s" "${arr[@]}")"
-    enc="${enc:${#sep}}"
-    IFS=$old_ifs
-    echo "$enc"
+    base64 -w 0 <(travis_yml "$@")
 }
 
 # configure docker volumes

--- a/arch-travis.sh
+++ b/arch-travis.sh
@@ -43,7 +43,7 @@ CONFIG_PACKAGES=$(encode_config arch packages)
 CONFIG_REPOS=$(encode_config arch repos)
 CONFIG_VOLUMES=$(configure_volumes)
 
-mapfile -t envs < <(ruby -e 'ENV.each {|key,_| if not ["PATH","USER","HOME","GOROOT"].include?(key) then puts "-e #{key}" end}')
+mapfile -t envs < <(ruby -e 'ENV.each {|key,_| if not ["PATH","USER","HOME","GOROOT","LC_ALL"].include?(key) then puts "-e #{key}" end}')
 
 
 docker run --rm \

--- a/init.sh
+++ b/init.sh
@@ -67,8 +67,11 @@ add_repositories() {
 
 # run before_install script defined in .travis.yml
 before_install() {
-  if [ -n "$CONFIG_BEFORE_INSTALL" ]; then
-    bash -xvec "$(bash_ps4); $CONFIG_BEFORE_INSTALL" 2>&1 || exit $?
+  if [ ${#CONFIG_BEFORE_INSTALL[@]} -gt 0 ]; then
+    for script in "${CONFIG_BEFORE_INSTALL[@]}"; do
+      echo "\$ $script"
+      eval "$script" || exit $?
+    done
   fi
 }
 
@@ -87,8 +90,11 @@ install_packages() {
 
 # run build scripts defined in .travis.yml
 build_scripts() {
-  if [ -n "$CONFIG_BUILD_SCRIPTS" ]; then
-    bash -xvec "$(bash_ps4); $CONFIG_BUILD_SCRIPTS" 2>&1 || exit $?
+  if [ ${#CONFIG_BUILD_SCRIPTS[@]} -gt 0 ]; then
+    for script in "${CONFIG_BUILD_SCRIPTS[@]}"; do
+      echo "\$ $script"
+      eval "$script" || exit $?
+    done
   else
     echo "No build scripts defined"
     exit 1

--- a/init.sh
+++ b/init.sh
@@ -32,10 +32,12 @@ repo_line=70
 read_config() {
   local old_ifs=$IFS
   local sep='::::'
+  CONFIG_BEFORE_INSTALL=${CONFIG_BEFORE_INSTALL//$sep/$'\n'}
   CONFIG_BUILD_SCRIPTS=${CONFIG_BUILD_SCRIPTS//$sep/$'\n'}
   CONFIG_PACKAGES=${CONFIG_PACKAGES//$sep/$'\n'}
   CONFIG_REPOS=${CONFIG_REPOS//$sep/$'\n'}
   IFS=$'\n'
+  CONFIG_BEFORE_INSTALL=("${CONFIG_BEFORE_INSTALL[@]}")
   CONFIG_BUILD_SCRIPTS=("${CONFIG_BUILD_SCRIPTS[@]}")
   CONFIG_PACKAGES=("${CONFIG_PACKAGES[@]}")
   if [[ -z "${CONFIG_REPOS}" ]]; then
@@ -60,6 +62,16 @@ add_repositories() {
 
     # update repos
     sudo pacman -Syy
+  fi
+}
+
+# run before_install script defined in .travis.yml
+before_install() {
+  if [ ${#CONFIG_BEFORE_INSTALL[@]} -gt 0 ]; then
+    for script in "${CONFIG_BEFORE_INSTALL[@]}"; do
+      echo "\$ $script"
+      eval "$script" || exit $?
+    done
   fi
 }
 
@@ -108,6 +120,7 @@ echo "travis_fold:start:arch_travis"
 arch_msg "Setting up Arch environment"
 add_repositories
 
+before_install
 upgrade_system
 install_packages
 

--- a/init.sh
+++ b/init.sh
@@ -106,8 +106,7 @@ install_c_compiler() {
 arch_msg() {
   lightblue='\033[1;34m'
   reset='\e[0m'
-  local args=("$@")
-  echo -e "${lightblue}${args[*]}${reset}"
+  echo -e "${lightblue}$*${reset}"
 }
 
 read_config

--- a/init.sh
+++ b/init.sh
@@ -39,13 +39,10 @@ bash_ps4() {
 
 # read arch-travis config from env
 read_config() {
-  local old_ifs=$IFS
-  IFS=$'\n'
-  CONFIG_BEFORE_INSTALL="$(decode_config "${CONFIG_BEFORE_INSTALL}")"
-  CONFIG_BUILD_SCRIPTS="$(decode_config "${CONFIG_BUILD_SCRIPTS}")"
-  CONFIG_PACKAGES="$(decode_config "${CONFIG_PACKAGES}")"
-  CONFIG_REPOS=($(decode_config "${CONFIG_REPOS}"))
-  IFS=$old_ifs
+  mapfile -t -d $'\0' CONFIG_BEFORE_INSTALL < <(decode_config "${CONFIG_BEFORE_INSTALL}")
+  mapfile -t -d $'\0' CONFIG_BUILD_SCRIPTS  < <(decode_config "${CONFIG_BUILD_SCRIPTS}")
+  mapfile -t -d $'\n' CONFIG_PACKAGES       < <(decode_config "${CONFIG_PACKAGES}")
+  mapfile -t -d $'\n' CONFIG_REPOS          < <(decode_config "${CONFIG_REPOS}")
 }
 
 # add custom repositories to pacman.conf
@@ -82,10 +79,9 @@ upgrade_system() {
 
 # install packages defined in .travis.yml
 install_packages() {
-  for package in "${CONFIG_PACKAGES[@]}"; do
-    mapfile -t packages <<< "$package"
-    yay -S "${packages[@]}" --noconfirm --needed
-  done
+  if [ ${#CONFIG_PACKAGES[@]} -gt 0 ]; then
+    yay -S "${CONFIG_PACKAGES[@]}" --noconfirm --needed
+  fi
 }
 
 # run build scripts defined in .travis.yml


### PR DESCRIPTION
- [x] add `makepkg.conf`
  - [x] add `MAKEFLAGS=-j2`
  - [x] add `COMPRESSXZ=(xz -T 2)`
  - [x] ~test if  `options+=(ccache) in `makepkg.conf` overrides default `options`~
- [x] install ccache in container
  - ~make `arch-travis.sh` add `ccache` to package list if `cache:ccache=true`~
  - [x] ~use `$TRAVIS_HOME/.ccache` to make use of travis `cache:ccache=true`~
  - [x] make ccache configuration persistent across updates. 
  - ~add `ccache_` config vars to `.travis.yml`~
- [x] add pacman cache
  - [x] ~add `casher add` invocation in `arch-travis.sh` on `cache:pacman=true`~
  - [x] move pacman cache to `$TRAVIS_HOME`
  - [x] clean old version of packages from `pacman pkg cache`
- [x] add `eval` ~and `realpath`~ to `arch.mount`
  - [x] use ruby `File.expand_path()` instead of `realpath` (missing from travis image)
refers #55 