### PR TITLE
Resolve arch:packages dependencies conflict.

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -80,7 +80,7 @@ upgrade_system() {
 # install packages defined in .travis.yml
 install_packages() {
   if [ ${#CONFIG_PACKAGES[@]} -gt 0 ]; then
-    yay -S "${CONFIG_PACKAGES[@]}" --noconfirm --needed
+    yay -S "${CONFIG_PACKAGES[@]}" --noconfirm --needed --useask
   fi
 }
 


### PR DESCRIPTION
Add --useask in yay invocation (init.sh/install_pacakges())
to resolve conflicts between dependencies of one package
overlapping with what's provided by other package.

Example:
coin-or-lemon depends on cblas, blas, lapack through coin-or-coinutils
openblas-lapack provides (cblas, blas, lapack)
alice-vision depends on both of them. That's introducing an unresolved
package conflict in yay, which in turns won't install openblas-lapack.