### PR TITLE
Fix overlapping dependencies.

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -80,7 +80,9 @@ upgrade_system() {
 # install packages defined in .travis.yml
 install_packages() {
   if [ ${#CONFIG_PACKAGES[@]} -gt 0 ]; then
-    yay -S "${CONFIG_PACKAGES[@]}" --noconfirm --needed --useask
+    for pkg in "${CONFIG_PACKAGES[@]}"; do
+      yay -S "$pkg" --noconfirm --needed --useask || exit $?
+    done
   fi
 }
 


### PR DESCRIPTION
Yay can't resolve overlapping dependencies in 'arch:packages' in single call.
We have to split yay call per package, to gave it a chance to resolve them.

* 'install_pacakges' should exit on `yay` error to prevent unresolved dependencies error in 'build_script'
Fix #63