### PR TITLE
Fix conflict with Travis arch keyword.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ compiler:
 services:
 - docker
 
-arch:
+archlinux:
   repos:
   - archlinuxfr=http://repo.archlinux.fr/$arch
   packages:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ sudo: required
 services:
 - docker
 
-arch:
+archlinux:
   repos:
   - papyros=http://dash.papyros.io/repos/$repo/$arch
   packages:
@@ -74,7 +74,7 @@ It is possible to use custom respositories by adding them to the `arch.repos`
 section of `.travis.yml` using the following format:
 
 ```yml
-arch:
+archlinux:
   repos:
     - repo-name=http://repo.com/path
 ```

--- a/arch-travis.sh
+++ b/arch-travis.sh
@@ -42,6 +42,16 @@ configure_volumes() (
     while read -r vol; do printf -- '-v "%s"\n' "$vol"; done<<<"${volumes[*]}"
 )
 
+# regression test for outdated arch-travis configuration scheme.
+{
+    if travis_yml arch script >/dev/null 2>&1; then
+      echo '*** WARNING! Your current arch-travis configuration is outdated'
+      echo '*** Update ".travis.yml": replacing "arch:" keyword with "archlinux:"'
+      echo '*** More info: https://github.com/mikkeloscar/arch-travis/issues/65'
+      exit 66
+    fi
+} >&2
+
 # read travis config
 CONFIG_BEFORE_INSTALL=$(encode_config --null archlinux before_install)
 CONFIG_BUILD_SCRIPTS=$(encode_config --null archlinux script)

--- a/arch-travis.sh
+++ b/arch-travis.sh
@@ -32,7 +32,7 @@ encode_config() {
 # configure docker volumes
 configure_volumes() (
     IFS=$'\n'
-    mapfile -t volumes < <(travis_yml arch mount)
+    mapfile -t volumes < <(travis_yml archlinux mount)
     [[ -z "${volumes[*]}" ]] && return 1
     # expand environment variables
     mapfile -t volumes < <(while read -r vol; do eval echo -e "$vol"; done <<<"${volumes[*]}")
@@ -43,10 +43,10 @@ configure_volumes() (
 )
 
 # read travis config
-CONFIG_BEFORE_INSTALL=$(encode_config --null arch before_install)
-CONFIG_BUILD_SCRIPTS=$(encode_config --null arch script)
-CONFIG_PACKAGES=$(encode_config arch packages)
-CONFIG_REPOS=$(encode_config arch repos)
+CONFIG_BEFORE_INSTALL=$(encode_config --null archlinux before_install)
+CONFIG_BUILD_SCRIPTS=$(encode_config --null archlinux script)
+CONFIG_PACKAGES=$(encode_config archlinux packages)
+CONFIG_REPOS=$(encode_config archlinux repos)
 #ubuntu bash is to old to have mapfile -d syntax [sic!]
 mapfile -t CONFIG_VOLUMES < <(configure_volumes)
 


### PR DESCRIPTION
- [x] Rename `.travis.yml` current keyword from `arch` to `archlinux`
- [x] Add warning for `.travis.yml` following deprecated scheme.