### PR TITLE
Fix dead mirror issue.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,7 @@ USER $UGNAME
 
 RUN \
     sudo reflector --verbose -l 10 \
-        --sort rate --save /etc/pacman.d/mirrorlist && \
-    sudo pacman -Rs reflector --noconfirm
+        --sort rate --save /etc/pacman.d/mirrorlist
 
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/bin/core_perl
 

--- a/init.sh
+++ b/init.sh
@@ -72,6 +72,12 @@ before_install() {
   fi
 }
 
+# update reflector to prevent dead mirror causing build to fail.
+update_reflector() {
+    sudo reflector --verbose -l 10 \
+        --sort rate --save /etc/pacman.d/mirrorlist
+}
+
 # upgrade system to avoid partial upgrade states
 upgrade_system() {
   sudo pacman -Syu --noconfirm
@@ -118,6 +124,7 @@ arch_msg "Setting up Arch environment"
 add_repositories
 
 before_install
+update_reflector
 upgrade_system
 install_packages
 


### PR DESCRIPTION
 Using `reflector` to populate pacman mirrorlist
could lead to an issue when the mirror is to slow
resulting in Travis terminating the worker thread
after 10 minutes period of inactivity.
 To mitigate this `reflector` mirrorlist need to
be updated every time.