### PR TITLE
Run privileged docker container.

### DIFF
--- a/arch-travis.sh
+++ b/arch-travis.sh
@@ -72,5 +72,6 @@ eval docker run --rm \
     -e CONFIG_BUILD_SCRIPTS="$CONFIG_BUILD_SCRIPTS" \
     -e CONFIG_PACKAGES="$CONFIG_PACKAGES" \
     -e CONFIG_REPOS="$CONFIG_REPOS" \
+    --privileged \
     "${envs[@]}" \
     mikkeloscar/arch-travis:latest


### PR DESCRIPTION
Necessary for the container build process to be
congruent with the one run on a local machine.

Without this some packages tend to fail.
[Relevent issue on Travis community](https://travis-ci.community/t/cant-get-folder-inode-inside-docker-container) 