### PR TITLE
Fix `pgp` key import.

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -87,7 +87,7 @@ upgrade_system() {
 install_packages() {
   if [ ${#CONFIG_PACKAGES[@]} -gt 0 ]; then
     for pkg in "${CONFIG_PACKAGES[@]}"; do
-      yay -S "$pkg" --noconfirm --needed --useask || exit $?
+      yay -S "$pkg" --noconfirm --needed --useask --gpgflags "--keyserver hkp://pool.sks-keyservers.net" || exit $?
     done
   fi
 }


### PR DESCRIPTION
When inside volatile docker container we do not have
`dirmngr` instantiated and keyserver has to be provided
in `gpg` call (`gpg --keyserver ${server_url}`)