### PR TITLE
Change discontinued gpg keyserver.

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -87,7 +87,7 @@ upgrade_system() {
 install_packages() {
   if [ ${#CONFIG_PACKAGES[@]} -gt 0 ]; then
     for pkg in "${CONFIG_PACKAGES[@]}"; do
-      yay -S "$pkg" --noconfirm --needed --useask --gpgflags "--keyserver hkp://pool.sks-keyservers.net" || exit $?
+      yay -S "$pkg" --noconfirm --needed --useask --gpgflags "--keyserver  hkps://keys.openpgp.org/" || exit $?
     done
   fi
 }


### PR DESCRIPTION
Default GnuPG key server SKS is dead since 25 of June: https://bugs.archlinux.org/task/71078
Use `keys.openpgp.org` as replacement before updated `gnupg` landed in Arch repo.
https://dev.gnupg.org/rG47c4e3e00a7ef55f954c14b3c237496e54a853c1